### PR TITLE
Fix GitHub Actions workflow syntax errors

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -53,8 +53,6 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
-        # Only start if use_database is true
-        if: ${{ inputs.use_database }}
 
       redis:
         image: redis:7-alpine
@@ -65,8 +63,6 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
-        # Only start if use_redis is true
-        if: ${{ inputs.use_redis }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -66,7 +66,7 @@ jobs:
         run: terraform validate -no-color
 
       - name: Write TF Vars
-        if: ${{ secrets.TF_VARS != '' }}
+        if: ${{ secrets.TF_VARS }}
         run: echo '${{ secrets.TF_VARS }}' > terraform.auto.tfvars.json
 
       - name: Terraform Plan


### PR DESCRIPTION
## Summary
Fixes syntax errors in terraform-plan.yml and python-test.yml that were blocking workflow validation.

## Issues Fixed

### terraform-plan.yml (line 69)
**Problem**: `if: ${{ secrets.TF_VARS != '' }}`
- Can't use comparison operators on secrets in if conditions
- GitHub Actions doesn't support this syntax

**Fix**: `if: ${{ secrets.TF_VARS }}`
- Check if secret is truthy (exists and non-empty)
- This is the correct pattern for reusable workflows

### python-test.yml (lines 57, 69)
**Problem**: `if:` conditionals on service containers
- Service containers don't support conditional execution
- GitHub Actions validation error: "Unexpected value 'if'"

**Fix**: Removed the `if` statements
- Services will always run (standard practice)
- Unused services don't break tests, they just run in background

## Context
These pre-existing errors were exposed when PR #5 (dependabot-auto-merge) was merged, as GitHub validates ALL workflows when any workflow changes.

## Test Plan
- [ ] Merge this PR
- [ ] Verify no workflow validation errors
- [ ] Verify terraform-plan workflow still works
- [ ] Verify python-test workflow still works

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>