### PR TITLE
Temporarily make zizmor advisory in workflow-ci

### DIFF
--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Run zizmor
         run: zizmor .github/workflows
+        continue-on-error: true
 
   smoke-security-scan:
     name: Smoke Reusable Security Scan


### PR DESCRIPTION
Makes zizmor non-blocking while we burn down legacy findings incrementally.