### PR TITLE
Dependabot: wait on required checks only

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Wait for checks to complete
         run: |
           echo "Waiting for all required checks to pass..."
-          gh pr checks "$PR_URL" --watch --interval 10
+          gh pr checks "$PR_URL" --required --watch --interval 10
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #18. Prevents auto-merge workflow hangs by waiting only on required PR checks.