### PR TITLE
Zizmor phase 2: harden dependabot-auto-merge and workflow-ci

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -79,9 +79,10 @@ jobs:
           inputs.auto_merge_patch == true
         run: |
           echo "Auto-merging patch update"
-          gh pr merge --auto --${{ inputs.merge_method }} "$PR_URL"
+          gh pr merge --auto "$MERGE_FLAG" "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
+          MERGE_FLAG: ${{ steps.merge_method.outputs.flag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for minor updates
@@ -90,9 +91,10 @@ jobs:
           inputs.auto_merge_minor == true
         run: |
           echo "Auto-merging minor update"
-          gh pr merge --auto --${{ inputs.merge_method }} "$PR_URL"
+          gh pr merge --auto "$MERGE_FLAG" "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
+          MERGE_FLAG: ${{ steps.merge_method.outputs.flag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for major updates
@@ -101,9 +103,10 @@ jobs:
           inputs.auto_merge_major == true
         run: |
           echo "Auto-merging major update"
-          gh pr merge --auto --${{ inputs.merge_method }} "$PR_URL"
+          gh pr merge --auto "$MERGE_FLAG" "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
+          MERGE_FLAG: ${{ steps.merge_method.outputs.flag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on major updates requiring manual review

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -23,7 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Run actionlint
         uses: reviewdog/action-actionlint@30f054494d5c1aa100ec4e57d1c7601100fc8f45 # v1.71.0
@@ -34,10 +36,12 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: Install zizmor
         run: cargo install --locked zizmor


### PR DESCRIPTION
Closes #20. Reduces phase-2 scoped findings by pinning workflow actions, disabling checkout credential persistence, and removing high-confidence template injection in merge commands.