### PR TITLE
Zizmor phase 3: harden hugo and jekyll deploy workflows

### DIFF
--- a/.github/workflows/hugo-deploy.yml
+++ b/.github/workflows/hugo-deploy.yml
@@ -46,24 +46,25 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ inputs.go_version }}
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@e3b661c523413d13d642651a5ba5fc0d2b344c0d # v3
         with:
           hugo-version: ${{ inputs.hugo_version }}
           extended: ${{ inputs.hugo_extended }}
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Ensure Relearn Theme
         run: |
@@ -90,10 +91,17 @@ jobs:
           GONOSUMDB: ${{ inputs.gonosumdb }}
           HUGO_ENVIRONMENT: ${{ inputs.hugo_environment }}
           HUGO_ENV: ${{ inputs.hugo_environment }}
-        run: hugo --config hugo.toml --minify --baseURL "${{ steps.pages.outputs.base_url }}" ${{ inputs.hugo_args }}
+          BASE_URL: ${{ steps.pages.outputs.base_url }}
+          HUGO_ARGS: ${{ inputs.hugo_args }}
+        run: |
+          EXTRA_ARGS=()
+          if [ -n "$HUGO_ARGS" ]; then
+            read -r -a EXTRA_ARGS <<< "$HUGO_ARGS"
+          fi
+          hugo --config hugo.toml --minify --baseURL "$BASE_URL" "${EXTRA_ARGS[@]}"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: ./public
 
@@ -108,4 +116,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/jekyll-deploy.yml
+++ b/.github/workflows/jekyll-deploy.yml
@@ -21,25 +21,28 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
         with:
           ruby-version: ${{ inputs.ruby_version }}
           bundler-cache: true
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4
 
       - name: Build with Jekyll
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: ${{ inputs.jekyll_env }}
+          BASE_PATH: ${{ steps.pages.outputs.base_path }}
+        run: bundle exec jekyll build --baseurl "$BASE_PATH"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
 
   deploy:
     name: Deploy to GitHub Pages
@@ -52,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
Closes #22. Pins actions to SHAs, disables checkout credential persistence, and removes template-injection patterns while preserving deploy behavior.