### PR TITLE
Phase 9: harden link-check and verify jekyll-quality

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -25,10 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Check links with lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2
         with:
           args: ${{ inputs.lychee_args }} ${{ inputs.markdown_globs }}
           fail: ${{ inputs.fail_on_error }}
@@ -37,7 +39,7 @@ jobs:
 
       - name: Create issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const issue = await github.rest.issues.create({


### PR DESCRIPTION
## Summary
- pin unpinned actions in link-check workflow
- set checkout persist-credentials to false in link-check
- verify targeted zizmor checks for link-check and jekyll-quality are clean

Closes #34