### PR TITLE
Phase 10: finalize zizmor gating and cleanup

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -113,9 +113,15 @@ jobs:
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-major' &&
           inputs.auto_merge_major == false
+        env:
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          PREVIOUS_VERSION: ${{ steps.metadata.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          body=$(cat <<'EOF'
-          **Major version update detected**: ${{ steps.metadata.outputs.dependency-names }} from ${{ steps.metadata.outputs.previous-version }} to ${{ steps.metadata.outputs.new-version }}
+          body=$(cat <<EOF
+          **Major version update detected**: ${DEPENDENCY_NAMES} from ${PREVIOUS_VERSION} to ${NEW_VERSION}
 
           Auto-merge is disabled for major updates in this repository. Please review the following before merging:
           - Breaking changes in the changelog
@@ -127,9 +133,6 @@ jobs:
           EOF
           )
           gh pr comment "$PR_URL" --body "$body"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on minor updates requiring manual review
         if: |

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -33,7 +33,6 @@ jobs:
   zizmor:
     name: Audit Workflows (zizmor)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -48,7 +47,6 @@ jobs:
 
       - name: Run zizmor
         run: zizmor .github/workflows
-        continue-on-error: true
 
   smoke-security-scan:
     name: Smoke Reusable Security Scan

--- a/docs/workflow-security.md
+++ b/docs/workflow-security.md
@@ -1,0 +1,16 @@
+# Workflow Security Policy
+
+## Zizmor Gating
+
+As of Phase 10 (`#33`), `zizmor` is a blocking check in `.github/workflows/workflow-ci.yml`.
+
+Policy:
+
+- No unsuppressed high-confidence findings are permitted.
+- Low-confidence findings should be fixed when practical.
+- Suppressions must include a rationale in code review/PR context.
+
+Current disposition:
+
+- Remaining high/medium findings: none.
+- Remaining informational findings: none after refactoring `dependabot-auto-merge.yml` to avoid inline template expansion in shell `run` blocks.


### PR DESCRIPTION
## Summary
- refactor dependabot major-update comment step to avoid inline template expansion in shell
- switch `zizmor` in `workflow-ci` from advisory to blocking
- add workflow security policy note documenting Phase 10 disposition and gating decision

## Validation
- `zizmor .github/workflows` reports: No findings to report
- `actionlint` passes locally

Closes #33
