### PR TITLE
Enforce immutable shared workflow refs

### DIFF
--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -1,6 +1,7 @@
 name: Workflow CI
 
 on:
+  workflow_call:
   pull_request:
     paths:
       - .github/workflows/**
@@ -18,6 +19,18 @@ permissions:
   pull-requests: read
 
 jobs:
+  shared-workflow-ref-policy:
+    name: Enforce Shared Workflow SHA Pinning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Enforce immutable pins for shared platform workflows
+        run: ./scripts/check-platform-workflow-ref-pinning.sh
+
   actionlint:
     name: Lint Workflows (actionlint)
     runs-on: ubuntu-latest
@@ -47,12 +60,20 @@ jobs:
 
   smoke-security-scan:
     name: Smoke Reusable Security Scan
+    needs:
+      - shared-workflow-ref-policy
+      - actionlint
+      - zizmor
     uses: ./.github/workflows/security-scan.yml
     with:
       fetch_depth: 1
 
   smoke-container-build:
     name: Smoke Reusable Container Build
+    needs:
+      - shared-workflow-ref-policy
+      - actionlint
+      - zizmor
     permissions:
       contents: read
       packages: write

--- a/README.md
+++ b/README.md
@@ -310,15 +310,18 @@ When adding new workflows:
 
 **Pinning versions:**
 ```yaml
-# Pin to specific commit (most stable)
-uses: zavestudios/platform-pipelines/.github/workflows/terraform-rds.yml@a1b2c3d
+# Governed repositories must pin to a specific 40-character commit SHA
+uses: zavestudios/platform-pipelines/.github/workflows/terraform-rds.yml@0123456789abcdef0123456789abcdef01234567
 
-# Pin to tag (recommended for production)
+# Mutable tags are not permitted for governed repositories
 uses: zavestudios/platform-pipelines/.github/workflows/terraform-rds.yml@v1.0.0
 
-# Use branch (gets latest updates)
+# Floating branches such as @main are not permitted for governed repositories
 uses: zavestudios/platform-pipelines/.github/workflows/terraform-rds.yml@main
 ```
+
+For governed `tenant` and `portfolio` repositories, shared workflow refs must use
+an immutable 40-character commit SHA.
 
 ## Repository Structure
 

--- a/docs/ansible-workflows.md
+++ b/docs/ansible-workflows.md
@@ -146,6 +146,7 @@ jobs:
 Uses shared `platform-pipelines/workflow-ci.yml`:
 - **actionlint:** Validates workflow syntax and logic
 - **zizmor:** Security audit for workflows (script injection, permissions, action pinning)
+- **shared workflow ref policy:** Rejects `zavestudios/platform-pipelines` reusable workflow refs that are not pinned to immutable SHAs
 
 **Example implementation:**
 ```yaml
@@ -165,7 +166,7 @@ on:
 jobs:
   validate-workflows:
     name: Validate GitHub Actions Workflows
-    uses: zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@main
+    uses: zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@0123456789abcdef0123456789abcdef01234567
 ```
 
 **When to run manually:** After modifying workflow files

--- a/docs/workflow-security.md
+++ b/docs/workflow-security.md
@@ -14,3 +14,14 @@ Current disposition:
 
 - Remaining high/medium findings: none.
 - Remaining informational findings: none after refactoring `dependabot-auto-merge.yml` to avoid inline template expansion in shell `run` blocks.
+
+## Shared Workflow Ref Pinning
+
+`.github/workflows/workflow-ci.yml` also enforces immutable pinning for
+`zavestudios/platform-pipelines` reusable workflow refs.
+
+Policy:
+
+- Governed repositories must pin shared workflow refs to 40-character commit SHAs.
+- Floating refs such as `@main` and mutable tags are not permitted for governed consumers.
+- Local workflow refs such as `./.github/workflows/foo.yml` are outside the scope of this check.

--- a/scripts/check-platform-workflow-ref-pinning.sh
+++ b/scripts/check-platform-workflow-ref-pinning.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${1:-.}"
+workflow_dir="${repo_root}/.github/workflows"
+
+if [[ ! -d "${workflow_dir}" ]]; then
+  echo "No .github/workflows directory found under ${repo_root}; skipping shared workflow ref pinning check."
+  exit 0
+fi
+
+violations="$(
+  rg -n --pcre2 \
+    'uses:\s*zavestudios/platform-pipelines/\.github/workflows/[^@[:space:]]+@(?![0-9a-f]{40}\b)[^[:space:]]+' \
+    "${workflow_dir}" || true
+)"
+
+if [[ -n "${violations}" ]]; then
+  cat <<EOF
+Found non-compliant shared workflow refs. Governed repositories must pin
+zavestudios/platform-pipelines reusable workflow refs to immutable 40-character
+commit SHAs.
+
+Violations:
+${violations}
+
+Example fix:
+  uses: zavestudios/platform-pipelines/.github/workflows/security-scan.yml@0123456789abcdef0123456789abcdef01234567
+EOF
+  exit 1
+fi
+
+echo "All zavestudios/platform-pipelines reusable workflow refs are pinned to immutable SHAs."


### PR DESCRIPTION
## Summary
- make `workflow-ci.yml` reusable via `workflow_call`
- add a policy gate that rejects non-SHA refs for `zavestudios/platform-pipelines` reusable workflows
- document the governed-repository requirement to pin shared workflow refs to immutable 40-character commit SHAs

## Testing
- ran `bash scripts/check-platform-workflow-ref-pinning.sh /Users/xavierlopez/Dev/platform-pipelines`

## Notes
- this adds the enforcement surface in `platform-pipelines`
- governed consumer repos will still need to call `workflow-ci.yml` for the policy to run in their own CI