### PR TITLE
Make workflow validator self-contained

### DIFF
--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -29,7 +29,26 @@ jobs:
           persist-credentials: false
 
       - name: Enforce immutable pins for shared platform workflows
-        run: ./scripts/check-platform-workflow-ref-pinning.sh
+        run: |
+          violations="$(
+            rg -n --pcre2 \
+              'uses:\s*zavestudios/platform-pipelines/\.github/workflows/[^@[:space:]]+@(?![0-9a-f]{40}\b)[^[:space:]]+' \
+              .github/workflows || true
+          )"
+
+          if [[ -n "${violations}" ]]; then
+            cat <<EOF
+          Found non-compliant shared workflow refs. Governed repositories must pin
+          zavestudios/platform-pipelines reusable workflow refs to immutable
+          40-character commit SHAs.
+
+          Violations:
+          ${violations}
+          EOF
+            exit 1
+          fi
+
+          echo "All zavestudios/platform-pipelines reusable workflow refs are pinned to immutable SHAs."
 
   actionlint:
     name: Lint Workflows (actionlint)
@@ -56,7 +75,12 @@ jobs:
         run: cargo install --locked zizmor
 
       - name: Run zizmor
-        run: zizmor --config .github/zizmor.yml .github/workflows
+        run: |
+          if [[ -f .github/zizmor.yml ]]; then
+            zizmor --config .github/zizmor.yml .github/workflows
+          else
+            zizmor .github/workflows
+          fi
 
   smoke-security-scan:
     name: Smoke Reusable Security Scan

--- a/docs/workflow-security.md
+++ b/docs/workflow-security.md
@@ -25,3 +25,4 @@ Policy:
 - Governed repositories must pin shared workflow refs to 40-character commit SHAs.
 - Floating refs such as `@main` and mutable tags are not permitted for governed consumers.
 - Local workflow refs such as `./.github/workflows/foo.yml` are outside the scope of this check.
+- When `workflow-ci.yml` runs as a reusable workflow, it evaluates the caller repository's workflow files directly and does not require caller-local copies of platform-pipelines helper assets.


### PR DESCRIPTION
## Summary
- inline the shared workflow SHA-pinning check in `workflow-ci.yml`
- make `zizmor` use caller-repo config only when `.github/zizmor.yml` exists
- document that the reusable validator evaluates caller workflows directly

## Why
The first reusable-validator rollout failed in consumer repos because `workflow-ci.yml` assumed caller-local copies of `platform-pipelines` helper assets existed.

## Testing
- validated the failing GitHub Actions logs from `zavestudios` PR #94
- updated the reusable workflow to stop depending on caller-local helper paths