### PR TITLE
Skip workflow smoke jobs in consumer repos

### DIFF
--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -84,6 +84,7 @@ jobs:
 
   smoke-security-scan:
     name: Smoke Reusable Security Scan
+    if: github.repository == 'zavestudios/platform-pipelines'
     needs:
       - shared-workflow-ref-policy
       - actionlint
@@ -94,6 +95,7 @@ jobs:
 
   smoke-container-build:
     name: Smoke Reusable Container Build
+    if: github.repository == 'zavestudios/platform-pipelines'
     needs:
       - shared-workflow-ref-policy
       - actionlint


### PR DESCRIPTION
## Summary
- run workflow smoke jobs only in `zavestudios/platform-pipelines`
- avoid assuming consumer repos contain `platform-pipelines` fixture files

## Why
The reusable validator still failed in consumer repos because the smoke jobs referenced `.github/fixtures/...`, which only exists in `platform-pipelines`.

## Testing
- derived from the failing `zavestudios` workflow-validation run showing missing `.github/fixtures`