### PR TITLE
feat: kyverno-validate reusable workflow for CI policy pre-validation

### DIFF
--- a/.github/workflows/kyverno-validate.yml
+++ b/.github/workflows/kyverno-validate.yml
@@ -1,0 +1,57 @@
+name: Kyverno Validate
+
+on:
+  workflow_call:
+    inputs:
+      manifests_artifact:
+        description: 'Artifact name containing rendered manifests to validate'
+        required: true
+        type: string
+      policies_artifact:
+        description: 'Artifact name containing enforced Kyverno ClusterPolicy files'
+        required: false
+        type: string
+        default: 'kyverno-enforce-policies'
+
+permissions:
+  contents: read
+
+jobs:
+  kyverno-validate:
+    name: Kyverno Policy Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download manifests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ inputs.manifests_artifact }}
+          path: manifests
+
+      - name: Download policies
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ inputs.policies_artifact }}
+          path: policies
+
+      - name: Install kyverno CLI
+        env:
+          KYVERNO_VERSION: v1.16.4
+        run: |
+          curl -sLO "https://github.com/kyverno/kyverno/releases/download/${KYVERNO_VERSION}/kyverno-cli_${KYVERNO_VERSION}_linux_x86_64.tar.gz"
+          tar -xzf "kyverno-cli_${KYVERNO_VERSION}_linux_x86_64.tar.gz" kyverno
+          chmod +x kyverno
+          sudo mv kyverno /usr/local/bin/kyverno
+
+      - name: Validate manifests against enforced policies
+        run: |
+          if [[ -z "$(find policies -name '*.yaml' -o -name '*.yml' 2>/dev/null | head -1)" ]]; then
+            echo "No policy files found in policies/. Skipping validation."
+            exit 0
+          fi
+
+          if [[ -z "$(find manifests -name '*.yaml' -o -name '*.yml' 2>/dev/null | head -1)" ]]; then
+            echo "No manifest files found in manifests/. Skipping validation."
+            exit 0
+          fi
+
+          kyverno apply policies/ --resource manifests/ --detailed-results


### PR DESCRIPTION
## Summary

- Adds `kyverno-validate.yml` reusable workflow that validates rendered Kubernetes manifests against enforced Kyverno ClusterPolicies before they reach the cluster
- Accepts `manifests_artifact` and `policies_artifact` (default: `kyverno-enforce-policies`) as artifact inputs — no cross-repo checkout required
- Installs kyverno CLI v1.16.4 (matches BigBang 3.17.0 kyverno chart ~3.6.x) and runs `kyverno apply --detailed-results`
- Fails the PR if any Enforce-mode policy is violated; skips gracefully if either artifact is empty

## Merge sequence

This PR must merge **before** the companion gitops PR that calls this workflow. The gitops PR has a SHA placeholder that must be filled in with the commit SHA from this PR's merge.

## Test plan

- [ ] Actionlint passes on the new workflow
- [ ] Zizmor passes on the new workflow
- [ ] Smoke test: create a gitops PR with a changed HelmRelease and confirm the validate job is triggered and passes for a compliant manifest
- [ ] Confirm workflow fails on a manifest that drops no capabilities

## Related

- Closes zavestudios/platform-pipelines#60 (partial — gitops consumer in companion PR)
- Observed need during airflow platform-service deployment where policy violations surfaced 20m into Helm timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)