### PR TITLE
fix(container-build): make provenance and sbom configurable, default false

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -42,6 +42,16 @@ on:
         required: false
         type: string
         default: ""
+      provenance:
+        description: "Provenance attestation mode: false, mode=min, or mode=max. Default false for containerd/k3s compatibility."
+        required: false
+        type: string
+        default: "false"
+      sbom:
+        description: "Generate SBOM attestation. Default false for containerd/k3s compatibility."
+        required: false
+        type: boolean
+        default: false
     secrets:
       GH_TOKEN:
         required: true
@@ -147,10 +157,8 @@ jobs:
           build-args: ${{ steps.build_args.outputs.args }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          # BuildKit-attached attestations (SBOM + provenance).
-          # These are stored alongside the image in the OCI registry.
-          provenance: true
-          sbom: true
+          provenance: ${{ inputs.provenance }}
+          sbom: ${{ inputs.sbom }}
 
       - name: Trivy scan (fail on configured severity)
         if: ${{ inputs.push }}


### PR DESCRIPTION
## Problem

`provenance: true` and `sbom: true` were hardcoded. Docker build-push-action stores these as OCI attestation artifacts in a separate manifest within an image index. Containerd versions used by k3s fail to unpack this with:

```
mismatched image rootfs and manifest layers
```

The image index contains both the real image manifest and attestation manifests — containerd tries to unpack all of them as image layers and fails.

## Fix

Makes `provenance` and `sbom` configurable inputs, both defaulting to `false`. Callers that run on registries/runtimes that support OCI image indices (EKS, GKE, newer containerd) can opt in explicitly.

## Impact

Existing callers (keycloak, airflow) get `false` by default — no change to their workflow files needed. Any caller that wants attestations adds `provenance: mode=max` and `sbom: true` explicitly.